### PR TITLE
Setting RGB color calculates relative brightness based on maximum (not on/off)

### DIFF
--- a/lib/Hue.js
+++ b/lib/Hue.js
@@ -127,7 +127,7 @@ Hue.prototype.rgb = function(light,r,g,b,cb) {
   var params = {
     hue:182*hsv[0],
     sat:Math.ceil(254*hsv[1]),
-    bri:Math.ceil(254*hsv[2])
+    bri:Math.ceil(254*hsv[2]),
   }
 
   var opts = {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -13,7 +13,7 @@ exports.HueError = HueError;
 * @param {Integer} r Red value, 0-255
 * @param {Integer} g Green value, 0-255
 * @param {Integer} b Blue value, 0-255
-* @returns {Array} The HSV values EG: [h,s,v], [0-360 degrees, 0-1, 0-1]
+* @returns {Array} The HSV values EG: [h,s,v], [0-360 degrees, 0.0-1.0, 0.0-1.0]
 */
 exports.rgb2hsv = function(r, g, b) {
 
@@ -51,7 +51,7 @@ exports.rgb2hsv = function(r, g, b) {
         saturation = 1 - (min/max);
     }
 
-    return [Math.round(hue), Math.round(saturation), Math.round(value)];
+    return [Math.round(hue), saturation, value];
 }
 
 exports.parseHueResponse = function(r) {


### PR DESCRIPTION
## Problem

When using the hue cli, setting a values of RGB colors had odd effects. For example, when increasing the amount of green by a single value: 

```
hue lights 1 000100     # -> sets light to a nearly off green.  (EXPECTED)
hue lights 1 007F00     # -> sets light to a nearly off green   (UNEXPECTED)  
hue lights 1 008000     # -> sets light to a very bright green   (UNEXPECTED)            
hue lights 1 00FF00     # -> sets light to a very bright green   (EXPECTED)
```

One would expect that the difference of 1 color value between `007F00` and `008000` should be almost imperceptible, whereas the differences with the others should be obvious. 

# What is happening

In looking at the code under the covers I see that the API accepts a number between 0 and 254 https://www.burgestrand.se/hue-api/api/lights/

But the code in hue.js only allows for 0 or 254, and rounds the brightness to a binary. So anything less than .5 of FF is intrepreted as "basically off" (even though 0 still means some color).

# Proposal

Removing the round will return it to what seems to be its original behavior: brightness has a spectrum control rather than binary control.

# Alternatives

You could change the signature and keep all of this logic down in the hsv call. 